### PR TITLE
correct check for buffer

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -71,7 +71,7 @@ function syncFileToBuffer (filepath) {
 module.exports = function (input, callback) {
 
   // Handle buffer input
-  if (input instanceof Buffer) {
+  if (Buffer.isBuffer(input)) {
     return lookup(input);
   }
 


### PR DESCRIPTION
There are some cases where `instanceof Buffer` won't work, this fixes that by using the builtin `Buffer.isBuffer` instead.
